### PR TITLE
Wip bench 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Run `pip install mmr3`
 ## Benchmark
 `mmr3` is faster than `mmh3` on average, which is a popular murmurhash3 library written in C/C++ and Python. For the details, please refer to [benchmark.md](https://github.com/tushushu/murmurust/blob/main/benchmark.md).  
 
-| Item   | XS   | S    | M    | L    | XL   | Average | Faster |
-| ------ | ---- | ---- | ---- | ---- | ---- | ------- | ------ |
-| Hash32 | 2.1x | 2.0x | 1.8x | 1.1x | 0.8x | 1.6x    | Y      |
+| Item    | XS   | S    | M    | L    | XL   | Average | Faster |
+| ------- | ---- | ---- | ---- | ---- | ---- | ------- | ------ |
+| Hash32  | 1.9x | 1.8x | 1.8x | 1.3x | 1.0x | 1.6x    | Y      |
+| Hash128 | 1.9x | 1.9x | 1.8x | 1.5x | 1.0x | 1.6x    | Y      |
 
 
 ## Examples

--- a/benchmark.md
+++ b/benchmark.md
@@ -33,18 +33,19 @@ Hash128, the mmr3's speed is 6.4 times of mmh3 on average.
 
 Info:  
 ************************************************************
-Date: 2022-08-05 14:57:45   
+Date: 2022-08-21 09:47:07   
 System OS: Linux   
-CPU:  Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz   
-Python version: 3.10.5   
-mmr3 version: 1.2.0   
+CPU:  Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz   
+Python version: 3.10.6   
+mmr3 version: 1.3.0   
 mmh3 version: 3.0.0   
 ************************************************************
 
 Result:
 
-| Item   | XS   | S    | M    | L    | XL   | Average | Faster |
-| ------ | ---- | ---- | ---- | ---- | ---- | ------- | ------ |
-| Hash32 | 2.1x | 2.0x | 1.8x | 1.1x | 0.8x | 1.6x    | Y      |
+| Item    | XS   | S    | M    | L    | XL   | Average | Faster |
+| ------- | ---- | ---- | ---- | ---- | ---- | ------- | ------ |
+| Hash32  | 1.9x | 1.8x | 1.8x | 1.3x | 1.0x | 1.6x    | Y      |
+| Hash128 | 1.9x | 1.9x | 1.8x | 1.5x | 1.0x | 1.6x    | Y      |
 
-1 of 1 tasks are faster!
+2 of 2 tasks are faster!

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -163,6 +163,14 @@ class Hash32(Benchmarker):
         mmh3.hash(key, signed=False)
 
 
+class Hash128(Benchmarker):
+    def mmr3_fn(self, key: str) -> None:
+        mmr3.hash128_x64(key, seed=0, signed=False)
+
+    def other_fn(self, key: str) -> None:
+        mmh3.hash128(key, seed=0, signed=False)
+
+
 def _get_processor_name() -> str:
     if platform.system() == "Windows":
         return platform.processor()
@@ -202,7 +210,7 @@ def display_result() -> None:
     print()
     n_wins = 0
     total = 0
-    benchmarkers = [Hash32]
+    benchmarkers = [Hash32, Hash128]
     for cls in benchmarkers:
         result = cls().run()
         if total == 0:

--- a/requirements/bench.txt
+++ b/requirements/bench.txt
@@ -1,3 +1,3 @@
 -r common.txt
 # A-Z
-mmr3==1.2.0
+mmr3==1.3.0


### PR DESCRIPTION
Compare the benchmark between `mmr3` 1.3.0 and `mmh3` 3.0.0