### PR TITLE
Wip default para hash128

### DIFF
--- a/mmr3/Cargo.toml
+++ b/mmr3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmr3"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["tushushu"]
 edition = "2018"
 

--- a/mmr3/python/mmr3/__init__.py
+++ b/mmr3/python/mmr3/__init__.py
@@ -1,3 +1,3 @@
 from .mmr3 import fmix32, fmix64, hash32, hash128_x64  # noqa:F401
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/mmr3/src/lib.rs
+++ b/mmr3/src/lib.rs
@@ -76,7 +76,7 @@ fn hash32(_py: Python, key: &str, seed: u32, signed: bool) -> Py<PyAny> {
     }
 }
 
-#[pyfunction]
+#[pyfunction(seed = "0", signed = "false")]
 fn hash128_x64(_py: Python, key: &str, seed: u32, signed: bool) -> Py<PyAny> {
     let len = key.len();
     let bytes = key.as_bytes();


### PR DESCRIPTION
What's new?
- By default, for the parameters of `hash128`, let seed = "0", signed = "false".